### PR TITLE
added HTTP GET validation and adding site tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,22 @@ Also modeled in dotenv.txt and can be set in a .env file
 2. Add Silver Peak Edge Connect nodes to your EVE-NG lab
 - Change number of interfaces as desired (default is 4, auto-map supports up to 9)
 - Change console to 'vnc' (default is 'telnet')
-- Connect the first interface on each Edge Connect (e0) to be able to reach Orchestrator outside of EVE-NG (e.g. Management(Cloud0))
+- Connect the first interface on each Edge Connect (e0) to be able to reach Orchestrator
+    - Usually via Network object Management(Cloud0)
+
+3. Start the Edge Connects
 - Open the console to each Edge Connect to obtain it's IP address
+- Wait for the Edge Connects to power up and for the HTTP service to become responsive
 
 
 # Syntax
 
-Run the script and then enter each Edge Connect mgmt0 IP address to be bootstrapped. The script will check that the IP entered is a valid IP address and that it can currently ping the address.
+Run the script and then enter each Edge Connect mgmt0 IP address to be bootstrapped.
+
+The script will check the following readiness indicators to allow an IP to be added:
+- The IP entered is a valid IP address
+- The IP can be reached by ping
+- Performing a GET request returns a valid expected string URI from the Edge Connect
 
 When entry is complete mark 'n' and then confirm 'y' to proceed with the confirmed IP's.
 
@@ -40,17 +49,18 @@ Example:
 
 ```
 > python3 silverpeak_eve_ec_boostrap.py
-> Please enter IP of Edge Connect (e.g. 10.1.30.100): 10.1.30.67
-PING 10.1.30.67 (10.1.30.67): 56 data bytes
+> Please enter IP of Edge Connect (e.g. 10.1.30.100): 10.1.30.72
+PING 10.1.30.72 (10.1.30.72): 56 data bytes
 
---- 10.1.30.67 ping statistics ---
+--- 10.1.30.72 ping statistics ---
 1 packets transmitted, 1 packets received, 0.0% packet loss, 1 packets out of wait time
-round-trip min/avg/max/stddev = 3.389/3.389/3.389/0.000 ms
-> 10.1.30.67: Edge Connect has been added to list for bootstrap
+round-trip min/avg/max/stddev = 2.488/2.488/2.488/0.000 ms
+Edge Connect Unique ID: T3dpXc3_psB9YZj2tVIsFg
+> Please enter tag for Edge Connect (e.g. SITE-1, can be left blank): SITE-3
+> 10.1.30.72: Edge Connect has been added to list for bootstrap
 > Do you want to enter more Edge Connects? (y/n): n
 > These are the Edge Connects that will be bootstrapped:
-> 10.1.30.15
-> 10.1.30.69
+> 10.1.30.72
 > Proceed? (y/n): y
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv
 requests
 colored
 urllib3
+tqdm

--- a/silverpeak_ec_assign_orch.py
+++ b/silverpeak_ec_assign_orch.py
@@ -16,8 +16,8 @@ blue_text = colored.fg("steel_blue_1b") + colored.attr("bold")
 orange_text = colored.fg("dark_orange") + colored.attr("bold")
 
 
-def ec_assign_orch(ec_ip, orchestrator, account, accountKey, ec_user="admin", ec_pass="admin"):
-
+def ec_assign_orch(ec_ip, orchestrator, account, accountKey, ec_user="admin", ec_pass="admin", tag="",orch_check="n"):
+    print(tag)
     ec = ecosHelper(ec_ip, ec_user, ec_pass)
 
     ec.login()
@@ -28,7 +28,7 @@ def ec_assign_orch(ec_ip, orchestrator, account, accountKey, ec_user="admin", ec
         current_orchestrator = ec.get_orchestrator().json()
         print("Current Orchestrator: "+ stylize(current_orchestrator,blue_text))
     except:
-        print("Could not retrieve current Orchestrator for {0} due to {1}".format(ec_ip),Exception)
+        print("Could not retrieve current Orchestrator for {0} due to {1}".format(ec_ip,Exception))
     try:
         current_reg_status = ec.register_spPortal_status().json()
         print("Current Account: " + stylize(current_reg_status['account'],blue_text))
@@ -46,7 +46,10 @@ def ec_assign_orch(ec_ip, orchestrator, account, accountKey, ec_user="admin", ec
     except:
         print("Could not assign new Orchestrator {0} to Edge Connect {1}".format(orchestrator,ec_ip))
     try:
-        ec.register_spPortal(accountKey, account)
+        if tag == "":
+            ec.register_spPortal(accountKey, account)
+        else:
+            ec.register_spPortal(accountKey, account, site=tag)
     except:
         print("Could not assign new account {0} to Edge Connect {1}".format(account,ec_ip))
     
@@ -57,26 +60,29 @@ def ec_assign_orch(ec_ip, orchestrator, account, accountKey, ec_user="admin", ec
 
     time.sleep(7)
 
-    # Wait for up to 40 seconds for appliance reach new Orchestrator, checking every 10 seconds
-    print(stylize("########## WAITING FOR REGISTRATION ##########",orange_text))
 
-    reachable = 'unknown'
-    i = 0
+    if orch_check == 'y':
+        # Wait for up to 40 seconds for appliance reach new Orchestrator, checking every 10 seconds
+        print(stylize("########## WAITING FOR REGISTRATION ##########",orange_text))
 
-    while True:
-        i = i + 1
-        if (reachable != 'Reachable') and (i < 4):
-            try:
-                reachable = ec.get_orchestrator().json()[orchestrator]['webSocket']
-                if reachable != 'Reachable':
-                    print("ECV to Orchestrator web socket status: {0}, waiting 10s for next attempt".format(reachable))
-                    time.sleep(10)
-            except:
-                print("Could not get status from Edge Connect {0} (attempt: {1})".format(ec_ip,i))
-        else:
-            print("Could not reach Orchestrator after 4 attempts, moving on...")
-            break
+        reachable = 'unknown'
+        i = 0
 
+        while True:
+            i = i + 1
+            if (reachable != 'Reachable') and (i < 4):
+                try:
+                    reachable = ec.get_orchestrator().json()[orchestrator]['webSocket']
+                    if reachable != 'Reachable':
+                        print("ECV to Orchestrator web socket status: {0}, waiting 10s for next attempt".format(reachable))
+                        time.sleep(10)
+                except:
+                    print("Could not get status from Edge Connect {0} (attempt: {1})".format(ec_ip,i))
+            else:
+                print("Not registered with Orchestrator after 4 attempts, moving on...")
+                break
+    else:
+        pass
     
     try:
         # Retrieve new status before logging out
@@ -119,6 +125,6 @@ if __name__ == "__main__":
 
     # Login to Edge Connect
     if ec_default_creds == 'y':
-        ec_assign_orch(ec_ip, orchestrator, account, accountKey, )
+        ec_assign_orch(ec_ip, orchestrator, account, accountKey)
     else:
         ec_assign_orch(ec_ip, orchestrator, account, accountKey, ec_user, ec_pass)

--- a/silverpeak_ec_automap.py
+++ b/silverpeak_ec_automap.py
@@ -2,6 +2,7 @@ import colored
 from colored import stylize
 import getpass
 import time
+from tqdm import tqdm
 
 # Helper for API interaction with Silver Peak Edge Connect
 from ecosHelp import ecosHelper
@@ -65,24 +66,25 @@ def ec_auto_map(ec_ip, ec_user="admin", ec_pass="admin"):
     try:
         ec.modify_network_interfaces(ifInfo)
         # Per API documentation, waiting 30 seconds before another API call after performing a POST to /networkInterfaces
-        print(stylize("########## WAITING FOR NEXT API CALL ##########",orange_text))
+        print(stylize("\n########## WAITING FOR NEXT API CALL ##########",orange_text))
+        
         i = 0
-        while i < 5:
-            time.sleep(5)
-            print (stylize("#" * i, orange_text))
+        for i in tqdm(range(10)):
+            time.sleep(3)
             i = i + 1
+
     except:
         print("Unable to assign MAC addresses!")
 
     # Save changes on Edge Connect
-    print(stylize("########## SAVING CHANGES ##########",orange_text))
+    print(stylize("\n########## SAVING CHANGES ##########",orange_text))
     ec.save_changes()
 
     # Reboot Edge Connect if required
-    print(stylize("########## CHECKING FOR REBOOT STATUS ##########",orange_text))
+    print(stylize("\n########## CHECKING FOR REBOOT STATUS ##########",orange_text))
     reboot_required = ec.is_reboot_required().json()
     if reboot_required['isRebootRequired'] == True:
-        print(stylize("########## CONFIG COMPLETED - REBOOTING APPLIANCE ##########",orange_text))
+        print(stylize("\n########## CONFIG COMPLETED - REBOOTING APPLIANCE ##########",green_text))
         ec.request_reboot(applyBeforeReboot={"hostname":"eve-silverpeak"})
     else:
         print("No reboot required")
@@ -107,7 +109,7 @@ if __name__ == "__main__":
 
     # Auto-map interfaces to MAC addresses on Edge Connect
     if ec_default_creds == 'y':
-        eve_ec_auto_map(ec_ip)
+        ec_auto_map(ec_ip)
     else:
-        eve_ec_auto_map(ec_ip, ec_user, ec_pass)
+        ec_auto_map(ec_ip, ec_user, ec_pass)
 

--- a/silverpeak_eve_ec_bootstrap.py
+++ b/silverpeak_eve_ec_bootstrap.py
@@ -4,6 +4,7 @@ from colored import stylize
 import getpass
 import os
 import ipaddress
+from ecosHelp import ecosHelper
 from silverpeak_ec_automap import ec_auto_map
 from silverpeak_ec_assign_orch import ec_assign_orch
 
@@ -20,7 +21,15 @@ def valid_and_reachable(ec_ip):
         ping_check = os.system("ping -c 1 -W 2 " + ec_ip)
 
         if ping_check == 0:
-            return True
+            try:
+                ec = ecosHelper(ec_ip)
+                http_check = ec.ec_api_id
+                print("Edge Connect Unique ID: {0}".format(http_check))
+                return True
+            except:
+                print (stylize("{0}: Could not connect to Edge Connect via HTTP, please check again before adding".format(ec_ip),red_text))
+                return False
+
         else:
             print (stylize("{0}: Could not ping Edge Connect, please check again before adding".format(ec_ip),red_text))
             return False
@@ -52,13 +61,21 @@ enter_more_ec = "y"
 while enter_more_ec == "y":
     ec_ip = input(stylize("Please enter IP of Edge Connect (e.g. 10.1.30.100): ",blue_text))
 
-    if valid_and_reachable(ec_ip) == True:
-        print(stylize("{0}: Edge Connect has been added to list for bootstrap".format(ec_ip),green_text))
-        ec_ip_list.append(ec_ip)
+    if not any(ec['ec_ip'] == ec_ip for ec in ec_ip_list):
+        if valid_and_reachable(ec_ip) == True:
+            tag = input(stylize("Please enter tag for Edge Connect (e.g. SITE-1, can be left blank): ",blue_text))
+            print(stylize("{0}: Edge Connect has been added to list for bootstrap".format(ec_ip),green_text))
+            ec_ip_list.append({'ec_ip':ec_ip, 'tag':tag})
+        else:
+            pass
+    else:
+        print(stylize("{0} was a duplicate IP that you've already entered".format(ec_ip),red_text))
+
+    check = input(stylize("Do you want to enter more Edge Connects? (y/n): ",orange_text))
+    if check == "y" or check == "n":
+        enter_more_ec = check
     else:
         pass
-
-    enter_more_ec = input(stylize("Do you want to enter more Edge Connects? (y/n): ",orange_text))
 
 
 if not ec_ip_list:
@@ -68,26 +85,26 @@ if not ec_ip_list:
 else:
 
     print (stylize("These are the Edge Connects that will be bootstrapped:",blue_text))
-    for ec_ip in ec_ip_list:
-        print (ec_ip)
+    for ec in ec_ip_list:
+        print (ec['ec_ip'], " { TAG:", ec['tag'],"}")
 
     proceed = input(stylize("Proceed? (y/n): ",blue_text))
     if proceed == "y":
         # Assign Orchestrator and Account License to Edge Connect
-        for ec_ip in ec_ip_list:
+        for ec in ec_ip_list:
             try:
-                print("Assigning Orchestrator to {0}".format(ec_ip))
-                ec_assign_orch(ec_ip, orchestrator, account, accountKey)
+                print(stylize("\n\nAssigning Orchestrator to {0}".format(ec['ec_ip']),green_text))
+                ec_assign_orch(ec['ec_ip'], orchestrator, account, accountKey, tag=ec['tag'])
             except:
-                print(stylize("Failed to assign Orchestrator to Edge Connect at {0}".format(ec_ip),red_text))
+                print(stylize("\n\nFailed to assign Orchestrator to Edge Connect at {0}".format(ec['ec_ip']),red_text))
 
         # Map interfaces to MAC addresses, this will incur a reboot of the Edge Connect
-        for ec_ip in ec_ip_list:
+        for ec in ec_ip_list:
             try:
-                print("Mapping Interfaces on {0}".format(ec_ip))
-                ec_auto_map(ec_ip)
+                print(stylize("\n\nMapping Interfaces on {0}".format(ec['ec_ip']),green_text))
+                ec_auto_map(ec['ec_ip'])
             except:
-                print(stylize("Failed to auto-map Edge Connect at {0}".format(ec_ip),red_text))
+                print(stylize("\n\nFailed to auto-map Edge Connect at {0}".format(ec['ec_ip']),red_text))
 
     else:
         exit()


### PR DESCRIPTION
Added additional readiness validation when adding an Edge Connect IP
-valid ip address
-responds to ping
-responds with URI from generic GET request

Allows optionally assigning a site/tag to the ECV to use when registering with Orch to match with preconfigs